### PR TITLE
Fix Makefile missing separators and errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,13 @@
 CC = g++
 FLAGS = -std=c++11
 
-all install: convto convfrom
+all install: build convto convfrom
+
+build:
+	@mkdir build
 
 convto: convto.cpp
-  $(CC) $(FLAGS) convto.cpp -o build/convto
+	$(CC) $(FLAGS) convto.cpp -o build/convto
 
 convfrom: convfrom.cpp
-  $(CC) $(FLAGS) convfrom.cpp -o build/convfrom
+	$(CC) $(FLAGS) convfrom.cpp -o build/convfrom


### PR DESCRIPTION
Makefile has error which are now fixed and works perfectly.  
![Peek 2021-04-19 14-51](https://user-images.githubusercontent.com/61649925/115213243-f5cee580-a11e-11eb-9fcc-7838e3503be1.gif)
